### PR TITLE
fix: Update get token header example [SUP-968]

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ const secretKey = issuer_webhook_key; //provided in postman_environment.json
  
 const verifyToken = (req, res, next) => {
    // grab HMAC signature from Notify-signature header of request
-   const token = req.headers["notify-signature"];
+   const token = req.get("notify-signature");
  
    if (!token) {
        return res.status(403).send("A token is required for authentication");


### PR DESCRIPTION
Update code example to fetch headers using case insensitive req.get() method.

[Ticket](https://www.notion.so/kardhq/Benny-Failed-Webhook-concerns-128b55c6420f80d78ec3eda0c07760c1?pvs=4)